### PR TITLE
Fix displaying of >8bit RGB images with interleave mode  "none"

### DIFF
--- a/test/browser/index.html
+++ b/test/browser/index.html
@@ -135,13 +135,9 @@
   }
 
   function colorToCanvas(frameInfo, pixelData, imageData, interleaveMode) {
+    const planeSize = frameInfo.width * frameInfo.height;
+    const shift = frameInfo.bitsPerSample > 8 ? frameInfo.bitsPerSample - 8 : 0;
     let outOffset = 0;
-    const bytesPerSample = (frameInfo.bitsPerSample <= 8) ? 1 : 2;
-    let planeSize = frameInfo.width * frameInfo.height * bytesPerSample;
-    let shift = 0;
-    if(frameInfo.bitsPerSample >8) {
-      shift = 8;
-    }
     let inOffset = 0;
    
     for(var y=0; y < frameInfo.height; y++) {
@@ -255,7 +251,8 @@
   }
 
   function display(frameInfo, decodedBuffer, interleaveMode) {
-    const signed = $('#signed').is(":checked"); 
+    // Use the signed option for monochrome (1 component) image. Multi component images are always unsigned.
+    const signed = $('#signed').is(":checked") && frameInfo.componentCount === 1; 
 
     const pixelData = getPixelData(frameInfo, decodedBuffer, signed);
 


### PR DESCRIPTION
This fix resolved the problem that 16 bit RGB images with interleave mode  "none" are not correctly displayed.

Changed:
- The planeSize needs to be computed in number of samples, there is no need to multiply with bytesPerSample

- How many bits to shift depends on the number of bitsPerSample, 10 bit RGB images should now also display correctly (not tested).
Note 1:  6 bit RGB images would require an upshift (not solved)
Note 2: It may be faster to move the if (interleaveMode === 0) outside the loop, but the javascript engine may already do this.

- When dragging a RGB image, the signed option would be active by default, which would corrupt the colors. Color images are now always displayed unsigned. I may be better to also disable the checkbox when a RGB image is loaded.