### PR TITLE
Add .gitattributes file to prevent that bash script get cr+lf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,17 @@
+# Set default behavior to use unix line feeds.
+* text eol=lf
+
+# Explicit define text files types.
+*.cpp text diff=cpp
+*.h text diff=cpp
+*.sh text
+
+# Explicit exclude binary files.
+*.png binary
+*.jls binary
+*.JLS binary
+*.RAW binary
+
+# Export ignore all files that are only needed for git (used when downloading the repository as a zip file).
+.gitattributes export-ignore
+.gitignore export-ignore


### PR DESCRIPTION
Without a .gitattributes file the global git config determines how files are fetched.
It is essential that the bash script don't get cr+lf.